### PR TITLE
fix(safari): fixes crash on Safari

### DIFF
--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -20,9 +20,10 @@ class HTML5 extends Component {
     const { src, extraProps: { useAudioObject } } = nextProps
 
     if (useAudioObject) {
-      // update audio object source if necessary
+      // destroy and recreate audio object to clean up any browser state
       if (this.props.src !== src) {
-        this._player.src = src
+        this._destroyAudioObject()
+        this._createAudioObject(src)
       }
       // bind any new props to current audio object
       this._bindAudioObjectEvents(nextProps)


### PR DESCRIPTION
I asked Travis about this fix and he suggested a fork, so now we're on our own with regards to `react-media-player`.

Safari occasionally crashes during playback start/buffering. A workaround is destroying and recreating the `Audio` object each time, rather than changing the `src`. I'm assuming this cleans up any internal browser state.